### PR TITLE
fix Color:out for colors R, G or B values starting with 0x0

### DIFF
--- a/lua/wal-colors/color.lua
+++ b/lua/wal-colors/color.lua
@@ -182,7 +182,7 @@ end
 
 function Color:out()
   local r, g, b = hsv_to_rgb(self.hue, self.saturation, self.value)
-  local rgb_hexstring = string.format("#%2X%2X%2X", r, g, b)
+  local rgb_hexstring = string.format("#%02X%02X%02X", r, g, b)
   return rgb_hexstring
 end
 


### PR DESCRIPTION
```lua
Color = require"wal-colors.color".Color
print(Color.from_rgb(15, 16, 15):out()))
```
prints `# F10 F` instead of `#0F100F`.